### PR TITLE
[codex] Add AGENTS.md guidance aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/apps/example-app/AGENTS.md
+++ b/apps/example-app/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/vitest-react-native/AGENTS.md
+++ b/packages/vitest-react-native/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary

This change adds `AGENTS.md` symlinks that point to the existing `CLAUDE.md` guidance files at the repository root and in the main subtrees.

## Why

Some tooling and agent workflows look specifically for `AGENTS.md` when discovering repository instructions. Without these aliases, the existing guidance can be missed even though the repository already documents the expected behavior in `CLAUDE.md`.

## Impact

This keeps the instruction source single-sourced in `CLAUDE.md` while making the same guidance discoverable through the `AGENTS.md` filename convention.

## Validation

No runtime checks were needed. This is a symlink-only filesystem change.
