### PR TITLE
[codex] Fix Platform deep-import compatibility

### DIFF
--- a/packages/vitest-react-native/src/setup.ts
+++ b/packages/vitest-react-native/src/setup.ts
@@ -365,9 +365,8 @@ mock(
 // Platform
 mock(
   'react-native/Libraries/Utilities/Platform',
-  () => `{
-  __esModule: true,
-  default: {
+  () => `(() => {
+  const Platform = {
     OS: 'ios',
     Version: '17.0',
     isPad: false,
@@ -382,8 +381,9 @@ mock(
       if ('native' in obj) return obj.native;
       return obj.default;
     },
-  },
-}`
+  };
+  return { __esModule: true, default: Platform, ...Platform };
+})()`
 );
 
 // UIManager

--- a/test/__tests__/Platform.spec.tsx
+++ b/test/__tests__/Platform.spec.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
 import { test, expect, describe } from 'vitest';
 import { Platform, PlatformIOSStatic } from 'react-native';
 
@@ -91,5 +93,45 @@ describe('Platform', () => {
     expect(Platform.constants.reactNativeVersion.major).toBeDefined();
     expect(Platform.constants.reactNativeVersion.minor).toBeDefined();
     expect(Platform.constants.reactNativeVersion.patch).toBeDefined();
+  });
+
+  test('deep Platform import exposes the mocked platform as default export', () => {
+    const platformModule = require('react-native/Libraries/Utilities/Platform');
+
+    expect(platformModule.default.OS).toBe('ios');
+  });
+
+  test('deep Platform import also exposes direct CommonJS properties', () => {
+    const platformModule = require('react-native/Libraries/Utilities/Platform');
+
+    expect(platformModule.OS).toBe('ios');
+  });
+
+  test('processColor can read Platform.OS through the compatibility shim', () => {
+    const { processColor } = require('react-native');
+
+    expect(() => processColor('black')).not.toThrow();
+  });
+
+  test('deep processColor import can read Platform.OS through the compatibility shim', () => {
+    const processColor = require('react-native/Libraries/StyleSheet/processColor').default;
+
+    expect(() => processColor('black')).not.toThrow();
+  });
+
+  test('react-native-svg can import react-native processColor without crashing', () => {
+    expect(() => require('react-native-svg')).not.toThrow();
+  });
+
+  test('react-native-svg shapes can render without crashing in processColor', () => {
+    const { Svg, Circle } = require('react-native-svg');
+
+    expect(() =>
+      render(
+        <Svg>
+          <Circle cx={10} cy={10} r={5} fill="black" />
+        </Svg>
+      )
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes the deep `Platform` mock shape used by `vitest-react-native` so React Native consumers can access it through either `module.default` or direct CommonJS properties.

## Root cause

The mock for `react-native/Libraries/Utilities/Platform` only exposed the mocked object as a `default` export. Some consumers in the `processColor` path expect CommonJS-style direct properties, which can make `Platform.OS` unreachable and trigger the crash reported in issue #2.

## What changed

- update the deep `Platform` mock to return both `default: Platform` and the platform properties themselves
- add regression tests for deep `Platform` imports
- add regression tests for public and deep `processColor` imports
- add a `react-native-svg` render-path regression to cover the reported failure mode

## Validation

- `pnpm test:run test/__tests__/Platform.spec.tsx test/__tests__/View.spec.tsx apps/example-app/__tests__/Counter.test.tsx`
- `pnpm build`

Closes #2
