### PR TITLE
[codex] Handle JSX and Flow type stripping in third-party React Native dependencies

### DIFF
--- a/packages/vitest-react-native/src/plugin.ts
+++ b/packages/vitest-react-native/src/plugin.ts
@@ -1,11 +1,9 @@
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { createRequire } from 'module';
 import type { Plugin, UserConfig } from 'vite';
+import { transformReactNativeDependency } from './reactNativeDependencyTransform';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const require = createRequire(import.meta.url);
-const removeTypes = require('flow-remove-types');
 
 export interface VitestReactNativePluginOptions {
   /**
@@ -64,15 +62,7 @@ export function reactNative(options: VitestReactNativePluginOptions = {}): Plugi
       } as UserConfig;
     },
     transform(code, id) {
-      const normalized = id.replace(/\\/g, '/');
-      if (
-        (normalized.includes('/node_modules/react-native/') ||
-          normalized.includes('/node_modules/@react-native/')) &&
-        (id.endsWith('.js') || id.endsWith('.ios.js'))
-      ) {
-        const result = removeTypes(code, { all: true }).toString();
-        return { code: result, map: null };
-      }
+      return transformReactNativeDependency(code, id);
     },
   };
 }

--- a/packages/vitest-react-native/src/reactNativeDependencyTransform.ts
+++ b/packages/vitest-react-native/src/reactNativeDependencyTransform.ts
@@ -1,0 +1,79 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const removeTypes = require('flow-remove-types');
+const getEsbuild = (): typeof import('esbuild') => require('esbuild');
+
+const reactNativeSpecificExtensions = [
+  '.ios.js',
+  '.ios.jsx',
+  '.android.js',
+  '.android.jsx',
+  '.native.js',
+  '.native.jsx',
+];
+
+const transformableExtensions = ['.js', '.jsx', ...reactNativeSpecificExtensions];
+
+const normalize = (id: string): string => id.replace(/\\/g, '/');
+
+const getDependencyName = (id: string): string | null => {
+  const nodeModulesPath = '/node_modules/';
+  const normalized = normalize(id);
+  const nodeModulesIndex = normalized.lastIndexOf(nodeModulesPath);
+
+  if (nodeModulesIndex === -1) {
+    return null;
+  }
+
+  const dependencyPath = normalized.slice(nodeModulesIndex + nodeModulesPath.length);
+  const segments = dependencyPath.split('/');
+
+  if (segments[0]?.startsWith('@') && segments[1]) {
+    return `${segments[0]}/${segments[1]}`;
+  }
+
+  return segments[0] ?? null;
+};
+
+export const shouldTransformReactNativeDependency = (id: string): boolean => {
+  const normalized = normalize(id);
+
+  if (!normalized.includes('/node_modules/')) {
+    return false;
+  }
+
+  if (!transformableExtensions.some((extension) => normalized.endsWith(extension))) {
+    return false;
+  }
+
+  const dependencyName = getDependencyName(normalized);
+
+  if (!dependencyName) {
+    return false;
+  }
+
+  return (
+    dependencyName === 'react-native' ||
+    dependencyName.startsWith('@react-native/') ||
+    dependencyName.includes('react-native') ||
+    reactNativeSpecificExtensions.some((extension) => normalized.endsWith(extension))
+  );
+};
+
+export const transformReactNativeDependency = (
+  code: string,
+  id: string
+): { code: string; map: null } | undefined => {
+  if (!shouldTransformReactNativeDependency(id)) {
+    return undefined;
+  }
+
+  const flowStrippedCode = removeTypes(code, { all: true }).toString();
+  const transformed = getEsbuild().transformSync(flowStrippedCode, {
+    loader: 'jsx',
+    sourcefile: id,
+  });
+
+  return { code: transformed.code, map: null };
+};

--- a/test/__tests__/reactNativeDependencyTransform.spec.ts
+++ b/test/__tests__/reactNativeDependencyTransform.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import {
+  shouldTransformReactNativeDependency,
+  transformReactNativeDependency,
+} from '../../packages/vitest-react-native/src/reactNativeDependencyTransform';
+
+const dependencySource = `
+  import React from 'react';
+  import { View } from 'react-native';
+
+  type Props = {
+    title?: string,
+  };
+
+  export default function DateTimePickerModal(props: Props) {
+    return <View>{props.title}</View>;
+  }
+`;
+
+describe('reactNativeDependencyTransform', () => {
+  test('transforms third-party React Native dependencies with JSX in .js files', () => {
+    const result = transformReactNativeDependency(
+      dependencySource,
+      '/project/node_modules/react-native-modal-datetime-picker/src/DateTimePickerModal.ios.js'
+    );
+
+    expect(result).toBeDefined();
+    expect(result?.code).not.toContain('type Props');
+    expect(result?.code).not.toContain('<View>');
+    expect(result?.code).toContain('React.createElement');
+  });
+
+  test('leaves unrelated JavaScript dependencies untouched', () => {
+    expect(shouldTransformReactNativeDependency('/project/node_modules/lodash/index.js')).toBe(
+      false
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,32 +1,21 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vitest/config';
 import { resolve } from 'path';
-import { createRequire } from 'module';
 import type { Plugin } from 'vite';
+import { transformReactNativeDependency } from './packages/vitest-react-native/src/reactNativeDependencyTransform';
 
-const require = createRequire(import.meta.url);
-const removeTypes = require('flow-remove-types');
-
-function flowRemoveTypesPlugin(): Plugin {
+function reactNativeDependencyTransformPlugin(): Plugin {
   return {
-    name: 'flow-remove-types',
+    name: 'react-native-dependency-transform',
     enforce: 'pre',
     transform(code, id) {
-      const normalized = id.replace(/\\/g, '/');
-      if (
-        (normalized.includes('/node_modules/react-native/') ||
-          normalized.includes('/node_modules/@react-native/')) &&
-        (id.endsWith('.js') || id.endsWith('.ios.js'))
-      ) {
-        const result = removeTypes(code, { all: true }).toString();
-        return { code: result, map: null };
-      }
+      return transformReactNativeDependency(code, id);
     },
   };
 }
 
 export default defineConfig({
-  plugins: [react(), flowRemoveTypesPlugin()],
+  plugins: [react(), reactNativeDependencyTransformPlugin()],
   resolve: {
     extensions: [
       '.ios.js',


### PR DESCRIPTION
## Summary
- add a shared Vite transform for React Native ecosystem dependencies in `node_modules`
- compile JSX as well as strip Flow types so packages like `react-native-modal-datetime-picker` no longer fail during import analysis
- add a regression test covering a third-party `.ios.js` dependency with JSX

## Root cause
The plugin only transformed `react-native` and `@react-native` packages, and the transform only removed Flow types. Third-party React Native packages shipping JSX in `.js` files were skipped entirely, so Vite still saw raw JSX during dependency analysis.

## Validation
- `pnpm test:run test/__tests__/reactNativeDependencyTransform.spec.ts`

Closes #4

Closes #5