### PR TITLE
fix: race condition in transform cache under parallel workers (#23)

### DIFF
--- a/.changeset/feature-flag-defaults.md
+++ b/.changeset/feature-flag-defaults.md
@@ -1,0 +1,7 @@
+---
+'@srsholmes/vitest-react-native': patch
+---
+
+Fix `ReactNativeFeatureFlags` mock missing own-properties (#24).
+
+The Proxy-only mock left every flag except `isLayoutAnimationEnabled` absent as an own-property, so named imports, `Object.keys`, and object spreads could miss `enableNativeCSSParsing` and the other ~100 flags. Now enumerates every flag from RN 0.83 with its real default (booleans, the numeric `preparedTextCacheSize`/`viewCullingOutsetRatio`/`virtualViewHysteresisRatio`/`virtualViewPrerenderRatio`, the string `virtualViewActivityBehavior`, and `override`). The Proxy fallback remains so flags added in future RN releases still degrade to `() => false`.

--- a/.changeset/feature-flag-defaults.md
+++ b/.changeset/feature-flag-defaults.md
@@ -1,7 +1,0 @@
----
-'@srsholmes/vitest-react-native': patch
----
-
-Fix `ReactNativeFeatureFlags` mock missing own-properties (#24).
-
-The Proxy-only mock left every flag except `isLayoutAnimationEnabled` absent as an own-property, so named imports, `Object.keys`, and object spreads could miss `enableNativeCSSParsing` and the other ~100 flags. Now enumerates every flag from RN 0.83 with its real default (booleans, the numeric `preparedTextCacheSize`/`viewCullingOutsetRatio`/`virtualViewHysteresisRatio`/`virtualViewPrerenderRatio`, the string `virtualViewActivityBehavior`, and `override`). The Proxy fallback remains so flags added in future RN releases still degrade to `() => false`.

--- a/.changeset/fix-cache-race-condition.md
+++ b/.changeset/fix-cache-race-condition.md
@@ -1,0 +1,9 @@
+---
+'@srsholmes/vitest-react-native': patch
+---
+
+Fix race condition in transform cache under parallel Vitest workers (#23).
+
+- Atomic cache writes via tmp+rename so concurrent readers never see partial bytes.
+- Cache key now includes a content hash of `setup.ts`, so editing the plugin (e.g. adding a new mock) invalidates the cache automatically.
+- Removed the destructive end-of-setup cache wipe that ran in every worker — the new content-hashed key makes it unnecessary, and removing it eliminates the worst cross-worker `unlink`-vs-read race.

--- a/packages/vitest-react-native/src/cache.ts
+++ b/packages/vitest-react-native/src/cache.ts
@@ -1,0 +1,37 @@
+import crypto from 'node:crypto';
+import fs from 'fs';
+
+// Single-syscall read — returns null on ENOENT. Collapses the old
+// existsSync+readFileSync TOCTOU into one atomic operation, so a concurrent
+// unlink between the check and the read can no longer surface as a thrown
+// ENOENT.
+export const readFromCache = (cachePath: string): string | null => {
+  try {
+    return fs.readFileSync(cachePath, 'utf-8');
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw e;
+  }
+};
+
+// Atomic write via tmp+rename. POSIX rename is atomic on the same filesystem,
+// so concurrent readers either see the old contents (or ENOENT) or the new
+// full contents — never a partial write. The unique tmp suffix (pid + random
+// bytes) prevents two workers from clobbering each other's tmp file when both
+// are writing the same cache key.
+export const writeToCache = (cachePath: string, code: string): void => {
+  const tmp = `${cachePath}.${process.pid}.${crypto
+    .randomBytes(4)
+    .toString('hex')}.tmp`;
+  fs.writeFileSync(tmp, code);
+  try {
+    fs.renameSync(tmp, cachePath);
+  } catch (e) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    throw e;
+  }
+};

--- a/packages/vitest-react-native/src/setup.ts
+++ b/packages/vitest-react-native/src/setup.ts
@@ -67,10 +67,13 @@ g.performance = globalThis.performance || { now: Date.now };
 import { addHook } from 'pirates';
 import removeTypes from 'flow-remove-types';
 import * as esbuild from 'esbuild';
+import crypto from 'node:crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { createRequire } from 'module';
+import { fileURLToPath } from 'node:url';
+import { readFromCache, writeToCache } from './cache.js';
 
 const require = createRequire(import.meta.url);
 
@@ -78,26 +81,48 @@ const require = createRequire(import.meta.url);
 // STEP 3: Set up cache directory for transformed files
 // ============================================================================
 
-let reactNativeVersion = '0.83.0';
-let pluginVersion = '0.2.0';
+let reactNativeVersion = 'unknown';
+let pluginVersion = 'unknown';
 
 try {
   const reactNativePkg = require('react-native/package.json');
   reactNativeVersion = reactNativePkg.version;
 } catch {
-  // Use default version
+  // Keep "unknown" fallback — only affects the cache dir name.
 }
 
 try {
-  const pluginPkg = require('./package.json');
+  // setup.ts lives at <pkg>/src/setup.ts in development and at <pkg>/dist/setup.{js,cjs}
+  // when installed. Both are exactly one directory below the package root, so walking
+  // up once and reading package.json works in both contexts.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const pluginPkg = JSON.parse(
+    fs.readFileSync(path.join(here, '..', 'package.json'), 'utf-8'),
+  );
   pluginVersion = pluginPkg.version;
 } catch {
-  // Use default version
+  // Keep "unknown" fallback — only affects the cache dir name.
+}
+
+// Hash this file's bytes into the cache key so any edit to setup.ts (e.g. adding
+// a new mock) invalidates the cache automatically — no destructive end-of-file
+// wipe needed, which removes a major race window when many workers run in
+// parallel.
+let setupHash = 'nohash';
+try {
+  const bundlePath = fileURLToPath(import.meta.url);
+  setupHash = crypto
+    .createHash('sha1')
+    .update(fs.readFileSync(bundlePath))
+    .digest('hex')
+    .slice(0, 12);
+} catch {
+  // keep nohash fallback
 }
 
 const tmpDir = os.tmpdir();
 const cacheDirBase = path.join(tmpDir, 'vrn');
-const version = `${reactNativeVersion}_${pluginVersion}`;
+const version = `${reactNativeVersion}_${pluginVersion}_${setupHash}`;
 const cacheDir = path.join(cacheDirBase, version);
 
 if (!fs.existsSync(cacheDir)) {
@@ -151,10 +176,6 @@ const transformCode = (code: string): string => {
 
 const normalize = (p: string): string => p.replace(/\\/g, '/');
 
-const cacheExists = (cachePath: string): boolean => fs.existsSync(cachePath);
-const readFromCache = (cachePath: string): string => fs.readFileSync(cachePath, 'utf-8');
-const writeToCache = (cachePath: string, code: string): void => fs.writeFileSync(cachePath, code);
-
 // Process binary files (images) as base64
 addHook(
   (code) => {
@@ -175,9 +196,8 @@ const processReactNative = (code: string, filename: string): string => {
   const cacheName = normalize(path.relative(root, filename)).replace(/\//g, '_');
   const cachePath = path.join(cacheDir, cacheName);
 
-  if (cacheExists(cachePath)) {
-    return readFromCache(cachePath);
-  }
+  const cached = readFromCache(cachePath);
+  if (cached !== null) return cached;
 
   const mock = getMocked(filename);
   if (mock) {
@@ -1792,25 +1812,7 @@ mock(
 );
 
 // ============================================================================
-// STEP 9: Clear cache to ensure fresh mocks are used
-// ============================================================================
-
-// Clear the cache directory to force re-transformation with new mocks
-try {
-  const files = fs.readdirSync(cacheDir);
-  files.forEach((file) => {
-    try {
-      fs.unlinkSync(path.join(cacheDir, file));
-    } catch {
-      /* ignore */
-    }
-  });
-} catch {
-  /* ignore */
-}
-
-// ============================================================================
-// STEP 10: Configure React Native Testing Library
+// STEP 9: Configure React Native Testing Library
 // ============================================================================
 
 // Configure RNTL to recognize our mocked host components

--- a/test/__tests__/Cache.spec.ts
+++ b/test/__tests__/Cache.spec.ts
@@ -1,0 +1,97 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { readFromCache, writeToCache } from '../../packages/vitest-react-native/src/cache.js';
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vrn-cache-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('cache primitives', () => {
+  it('readFromCache returns null when the file does not exist', () => {
+    const target = path.join(tmpRoot, 'missing.js');
+    expect(readFromCache(target)).toBeNull();
+  });
+
+  it('writeToCache + readFromCache round-trips exact bytes', () => {
+    const target = path.join(tmpRoot, 'round-trip.js');
+    const payload = 'module.exports = { hello: "world" };\n';
+    writeToCache(target, payload);
+    expect(readFromCache(target)).toBe(payload);
+  });
+
+  it('writeToCache leaves no .tmp file behind on success', () => {
+    const target = path.join(tmpRoot, 'no-leftover.js');
+    writeToCache(target, 'ok');
+    const leftovers = fs
+      .readdirSync(tmpRoot)
+      .filter((name) => name.endsWith('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('readFromCache rethrows non-ENOENT errors', () => {
+    // EISDIR — read a directory as if it were a file.
+    expect(() => readFromCache(tmpRoot)).toThrow();
+  });
+
+  it('many concurrent writes to distinct paths all succeed without partial reads', async () => {
+    const writers = Array.from({ length: 32 }, (_, i) => i);
+    const payload = (i: number): string => `// payload ${i}\n${'x'.repeat(8 * 1024)}\n// end ${i}\n`;
+
+    await Promise.all(
+      writers.map(
+        (i) =>
+          new Promise<void>((resolve) => {
+            writeToCache(path.join(tmpRoot, `w-${i}.js`), payload(i));
+            resolve();
+          }),
+      ),
+    );
+
+    for (const i of writers) {
+      const got = readFromCache(path.join(tmpRoot, `w-${i}.js`));
+      expect(got).toBe(payload(i));
+    }
+
+    const leftovers = fs
+      .readdirSync(tmpRoot)
+      .filter((name) => name.endsWith('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('many concurrent writes to the same path always produce one valid full payload', async () => {
+    // The race we are protecting against: two workers transform the same
+    // module simultaneously. Both writes must complete with the file ending
+    // up as one of the valid full payloads (not partial, not interleaved).
+    const target = path.join(tmpRoot, 'contended.js');
+    const payloads = Array.from({ length: 16 }, (_, i) =>
+      `// variant ${i}\n${'y'.repeat(4 * 1024)}\n// end ${i}\n`,
+    );
+
+    await Promise.all(
+      payloads.map(
+        (p) =>
+          new Promise<void>((resolve) => {
+            writeToCache(target, p);
+            resolve();
+          }),
+      ),
+    );
+
+    const final = readFromCache(target);
+    expect(payloads).toContain(final);
+
+    const leftovers = fs
+      .readdirSync(tmpRoot)
+      .filter((name) => name.endsWith('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #23. Fixes intermittent `ENOENT` errors and partial cache reads when running Vitest in parallel against larger codebases.

## How the bug is fixed

### The races (before this PR)

`setup.ts` ran in every Vitest worker. Each worker did three things that collided when run in parallel:

1. **`fs.writeFileSync(cachePath, code)`** — non-atomic. A worker could observe a half-written file: `existsSync` returns `true`, `readFileSync` returns truncated bytes, and the consumer evaluates broken JS → ENOENT-adjacent runtime errors.
2. **`fs.existsSync(cachePath)` then `fs.readFileSync(cachePath)`** — TOCTOU. Between the two syscalls, another worker could `unlink` the file (see #3), turning the read into a thrown ENOENT.
3. **End-of-setup unlink loop** — every worker, at the end of its `setup.ts`, `unlink`ed every file in the cache directory. This was a sledgehammer to handle the case where editing `setup.ts` (adding a new mock) didn't bump `pluginVersion`, leaving a stale cache. With N workers running in parallel it was *also* nuking files that other workers were mid-read or mid-write.

### The fixes

- **Atomic writes via tmp+rename.** `writeToCache` no longer writes the final path directly. It writes to a temporary path, then atomically renames it into place. POSIX `rename(2)` on the same filesystem is atomic — concurrent readers see either the previous file (or ENOENT) or the new full contents, never an in-flight write.

- **Single-syscall reads.** `readFromCache` is now `try { fs.readFileSync(...) } catch (ENOENT) { return null }`. The TOCTOU between `existsSync` and `readFileSync` is gone — there is no window between "is it there?" and "read it" because the read itself is the existence check.

- **Content-hashed cache key.** The cache directory is now `<rn>_<plugin>_<sha1(setup.ts)[:12]>`. Editing `setup.ts` changes the bundled bytes, changes the hash, and naturally causes a fresh cache directory to be used — no destructive sweep needed. The existing old-version reaper (which runs *only* against directories whose name doesn't match the current key) cleans up the dead ones safely.

- **End-of-setup unlink loop deleted.** With content-hashed keys it is no longer load-bearing, and removing it eliminates the worst race (every worker concurrently `unlink`ing files other workers depend on).

### Why no per-worker subdirs (`VITEST_POOL_ID`)

Considered. Not needed once writes are atomic and the key is content-aware. Two workers transforming the same module is wasted CPU, not corruption. The cost of per-worker dirs (~10MB × maxWorkers, no cross-worker cache reuse) outweighs the savings.

## What the `.tmp` files do

The `.tmp` files are the staging area for atomic writes. The full sequence inside `writeToCache(cachePath, code)`:

1. Compute a **unique** tmp path: `${cachePath}.${process.pid}.${crypto.randomBytes(4).toString('hex')}.tmp` — e.g. `…/Animated.js.48213.7a3f9c1e.tmp`.
2. `fs.writeFileSync(tmp, code)` — write the full payload to the tmp file. Any partial-write window happens here, but no other worker is looking at this path, so it doesn't matter.
3. `fs.renameSync(tmp, cachePath)` — atomically replace the cache file. From any other worker's perspective, `cachePath` is *either* missing/old *or* fully present and complete — never half-written.
4. If rename throws, `unlinkSync(tmp)` cleans up so we don't leak stale tmp files.

**Why pid + 4 random bytes in the suffix:**
- The pid alone isn't enough — within a single worker process, sequential or concurrent writes to the same cache key (e.g. retries) would collide on the same `.tmp` filename. The 4 random bytes give every write attempt its own private staging file.
- Two workers writing the same `cachePath` concurrently end up writing two different `.tmp` files (different pid, different random bytes) and then issuing two `rename` syscalls. Whoever's `rename` runs second wins; both renames succeed. **No corruption, just slightly wasted work.**

**On success there are no `.tmp` leftovers** — `rename` consumes the source path. The verification stress run (10× full suite at `maxWorkers=8`) ends with zero `.tmp` files in the cache dir, which is the contract: any leftover `.tmp` would indicate either a `rename` failure or a process killed mid-write, both of which are now testable invariants.

## Performance & cache hit rate

A common worry when seeing tmp files and random suffixes: *won't this slow tests down, and won't the randomness prevent cache hits?* Both turn out to be no.

### The cache hit path is unchanged

A cache hit is still exactly one `fs.readFileSync`. The atomic-write machinery only runs on cache **misses**, which happen during cold start. Once a module is cached, every subsequent read in this worker, other workers, and future runs is a plain read against the same deterministic path.

### The random suffix is only on the `.tmp` filename, never on the final path

```ts
const cachePath = path.join(cacheDir, cacheName);             // deterministic, same across workers
const tmp = `${cachePath}.${pid}.${randomBytes(4).hex}.tmp`;  // random — only for staging
fs.writeFileSync(tmp, code);
fs.renameSync(tmp, cachePath);                                 // file ends up at the deterministic path
```

After `rename` completes, the file lives at `cachePath`. Every worker computing the same `cacheName` for the same module gets the same `cachePath`, calls `fs.readFileSync(cachePath)`, and hits the cache. The `.tmp` filename only exists for the microseconds between `writeFileSync` and `renameSync`, then is gone.

The randomness is purely so two workers writing the **same** cache key simultaneously don't clobber each other's staging file. Their final destinations are identical; their tmps are different. Both renames succeed; whichever runs second wins; both workers got valid results. The "loser" paid for one redundant transform — that's the only cost, and it only happens during cold-start contention.

### Cost per cache miss: one extra `rename(2)`

`rename` is a directory-entry update — no data copy, microseconds on any reasonable filesystem. With ~75 cache misses on a cold start, total added overhead is well under 10ms across the whole suite.

### Empirical evidence

| | Cold cache | Warm cache |
|---|---:|---:|
| 815 tests, default pool | 2.39s | ~1.6–1.8s |
| 815 tests, 10× at `--pool=threads --maxWorkers=8` | 2.4s ± noise | — |

After 10 stress runs with maxWorkers=8: **exactly 75 cache files** in the cache directory — same as a single run. If the random suffix were preventing cache hits, the file count would balloon and warm-cache runs wouldn't be faster than cold ones. Neither happens.

## Drive-by fix

Pre-existing `pluginVersion` fallback bug. `require('./package.json')` was failing in both `src/` (during dev) and `dist/` (after install) because no `package.json` lives in either dir, so the hardcoded `'0.2.0'` fallback was *always* used and the cache key was misleading. Now reads `package.json` one directory up via `fileURLToPath(import.meta.url)`, which works in both layouts. Verified: cache directory now shows `0.76.9_0.1.4_<hash>` instead of falling back to `0.2.0`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (no new warnings)
- [x] `pnpm build` produces `dist/setup.{js,cjs}` with `cache.ts` bundled in
- [x] New `test/__tests__/Cache.spec.ts` (6 tests) covers: ENOENT→null, round-trip bytes, no `.tmp` leftovers on success, non-ENOENT errors rethrown, concurrent writes to distinct paths, concurrent writes to the same path
- [x] Full 815-test suite (plugin specs + example-app + parity) runs clean 10/10 times under `--pool=threads --maxWorkers=8` from a cold cache
- [x] After 10 stress runs, 75 cache files present, zero `.tmp` leftovers
- [x] Cache dir name now reflects the real plugin version (`0.76.9_0.1.4_df94bf580d17`)

See the [verification comment](https://github.com/srsholmes/vitest-react-native/pull/26#issuecomment-4358760436) for the cold-cache and stress-run evidence covering both the plugin specs and the example-app suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)