### PR TITLE
ci: bump release workflow to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm for trusted publishing support
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary
- Release workflow was failing at `npm install -g npm@latest` with `Cannot find module 'promise-retry'` ([failing run](https://github.com/srsholmes/vitest-react-native/actions/runs/25209196230/job/73915975849))
- Root cause: Node 22's bundled npm 10 corrupts itself during the in-place self-upgrade to npm 11
- Fix: bump release workflow to Node 24, which ships with npm 11.x and supports OIDC trusted publishing natively, so the upgrade step can be dropped entirely

## Test plan
- [ ] Release workflow succeeds on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)