### PR TITLE
chore: add changeset for #24 feature-flag defaults fix

### DIFF
--- a/.changeset/feature-flag-defaults.md
+++ b/.changeset/feature-flag-defaults.md
@@ -1,0 +1,7 @@
+---
+'@srsholmes/vitest-react-native': patch
+---
+
+Fix `ReactNativeFeatureFlags` mock missing own-properties (#24).
+
+The Proxy-only mock left every flag except `isLayoutAnimationEnabled` absent as an own-property, so named imports, `Object.keys`, and object spreads could miss `enableNativeCSSParsing` and the other ~100 flags. Now enumerates every flag from RN 0.83 with its real default (booleans, the numeric `preparedTextCacheSize`/`viewCullingOutsetRatio`/`virtualViewHysteresisRatio`/`virtualViewPrerenderRatio`, the string `virtualViewActivityBehavior`, and `override`). The Proxy fallback remains so flags added in future RN releases still degrade to `() => false`.


### PR DESCRIPTION
## Summary

PR #25 was merged without a `.changeset/*.md` file, so its fix has not appeared in any release. This adds the missing changeset so the next release publishes the feature-flag-defaults fix as a standalone patch.

## Why a separate PR

So #24/#25 ships as its own release (e.g. `0.1.4`) rather than being bundled with the cache race-condition fix in #26 (which will then ship as `0.1.5`).

## After merging

1. `changesets/action` opens a Version PR bumping `0.1.3 → 0.1.4` with this entry in CHANGELOG.
2. Merge the Version PR.
3. Release workflow publishes `@srsholmes/vitest-react-native@0.1.4` to npm.
4. PR #26 (cache race fix) gets rebased onto the new main and follows the same flow for `0.1.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)